### PR TITLE
Install hplip-plugin in container image

### DIFF
--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
         procps \
         whois \
         wget \
+        expect \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -36,6 +37,15 @@ RUN wget -q https://www.bchemnet.com/suldr/pool/debian/extra/su/suldr-keyring_2_
     && dpkg -i suldr-keyring_2_all.deb && apt-get update \
     && apt-get install -y suld-driver2-1.00.39hp && apt-get clean -y \
     && rm -f suldr-keyring_2_all.deb && rm -rf /var/lib/apt/lists/*
+
+RUN expect << EOF \
+    spawn hp-plugin -i \
+    expect "Enter option (d=download*, p=specify path, q=quit) ?" \
+    send "d\r" \
+    expect "Do you accept the license terms for the plug-in (y=yes*, n=no, q=quit) ?" \
+    send "y\r" \
+    expect eof \
+    EOF
 
 COPY rootfs /
 


### PR DESCRIPTION
Add hplip-plugin to container image to support certain HP printers requiring proprietary plugin.

# Proposed Changes

Install `expect` to talk to command `hp-plugin`
Run expect-script to install hplip-plugin
